### PR TITLE
Fix for settings esc bug #15

### DIFF
--- a/PauseMenu.gd
+++ b/PauseMenu.gd
@@ -9,6 +9,7 @@ func _unhandled_input(event):
 		if event.is_action_pressed("ui_cancel"):
 			self.is_paused = !is_paused
 			visible = is_paused
+			$SettingsMenu.visible = false
 
 func set_is_paused(value):
 	is_paused = value


### PR DESCRIPTION
fixing bug #15

Added some code to ensure that when ESC is pressed from the Settings menu, it also re-hides the Settings menu. This means when you hit Esc again, you're taken back to the pause menu, correctly, rather than the Settings menu popping up as if it was never closed